### PR TITLE
styles(): mudanças no css de Sprints e Equipes

### DIFF
--- a/projeto-rjm/src/pages/Equipes.jsx
+++ b/projeto-rjm/src/pages/Equipes.jsx
@@ -93,9 +93,10 @@ export default function Equipes() {
                         <hr className={equipeStyle.hr1} color="#4a4a4a" />
                     </div>
                     {(eqs.length != 0) ? (
+                        <div className={equipeStyle.equipesDivCenter}>
                         <div className={equipeStyle.equipeFlex}>
                             {apr()}
-                        </div>
+                        </div></div>
                     ) : (
                         <>
                             <br /><br /><br />

--- a/projeto-rjm/src/pages/Sprints.jsx
+++ b/projeto-rjm/src/pages/Sprints.jsx
@@ -55,7 +55,7 @@ export default function Sprints() {
                     caminho(i.id, 'task')
                 }}>
                 
-                        <td>{i.nome}</td>
+                        <td className={StylesSprint.tdNome}>{i.nome}</td>
                         <td className={StylesSprint.sprintDatas}>{dataInicio}</td>
                         <td className={StylesSprint.sprintDatas}>{dataFim}</td>
                 

--- a/projeto-rjm/src/ui/styles/Equipes/Equipes.module.css
+++ b/projeto-rjm/src/ui/styles/Equipes/Equipes.module.css
@@ -1,7 +1,7 @@
 .equipeDiv{
     background-color: #212a36 ;
     color: white;
-    width: 450px;
+    width: 30%;
     height: 200px;
     padding: 15px;
     border-radius: 10px;
@@ -16,15 +16,22 @@
 
 }
 
+.equipesDivCenter{
+    width: 80vw;
+    display: flex;
+    justify-content: center;
+}
+
 .equipeFlex{
     display: flex;
-    width: 80vw;
+    width: 100%;
     height: max-content;
-    gap: 10px;
-    justify-content: center;
+    gap: 16px;
+    justify-content: flex-start;
     flex-wrap: wrap;
     align-content: flex-start;
     background-color: #151B23;
+    margin-left: 16px;
 }
 
 .botaoEditarEquipe{
@@ -54,8 +61,9 @@
 .paginaEquipes{
     display: grid;
     min-height: 90vh;
+
     grid-template-columns: 20vw 80vw;
-    grid-template-rows: 15vh calc(85vh - 60px);
+    grid-template-rows: 15vh auto;
     
 
     

--- a/projeto-rjm/src/ui/styles/Sprints/Sprints.module.css
+++ b/projeto-rjm/src/ui/styles/Sprints/Sprints.module.css
@@ -58,7 +58,7 @@
 
 .equipeFlex{
     display: flex;
-    width: 80vw;
+    width: 79vw;
     height: max-content;
     gap: 10px;
     justify-content: center;
@@ -95,7 +95,7 @@
     display: grid;
     min-height: 90vh;
     grid-template-columns: 20vw 79vw;
-    grid-template-rows: 15vh calc(85vh - 60px);
+    grid-template-rows: 15vh auto
     
 
     
@@ -160,6 +160,7 @@
     border: solid 1px rgba(80, 80, 80, 0.712);
     border-radius: 15px;
     padding: 5px;
+    margin-bottom: 50px;
 }
 
 .tableSprints{
@@ -209,4 +210,8 @@
 
 .sprintDatas{
     text-align: center;
+}
+
+.tdNome{
+    padding-left: 16px;
 }


### PR DESCRIPTION
Foi alterado o NavBar para cobrir a tela inteira quando o conteúdo estende-lá. Porém, ele não a cobre se tem pouco conteúdo (Tem que arrumar isso). Também foi arrumado a organização das divs de equipe para não ficar centralizado o tempo todo